### PR TITLE
Update `publish.yml` to handle CI_TAG for all commit types

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,9 +38,14 @@ jobs:
           restore-keys: |
             gradle-build-cache-${{ runner.os }}-
 
-      - name: Set CI_TAG for release tags (strip leading 'v')
-        if: startsWith(github.ref, 'refs/tags/')
-        run: echo "CI_TAG=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+      - name: Set CI_TAG
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "CI_TAG=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          else
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo "CI_TAG=0.0.1-${SHORT_SHA}-SNAPSHOT" >> "$GITHUB_ENV"
+          fi
 
       - name: Decode signing key
         run: |


### PR DESCRIPTION
### Description

This pull request updates the `publish.yml` workflow:

- Adds functionality to set `CI_TAG` for untagged commits by using the short commit SHA.  
- Ensures proper handling of both tagged and untagged commits for consistent build tagging.  

### Checklist

- [ ] I have added tests related to this PR, as needed.
- [ ] I have updated the documentation as needed.
- [ ] I have ensured that this PR does not introduce unintended breaking changes.